### PR TITLE
feat: expose table_name configuration for ResponsesStoreReference

### DIFF
--- a/src/llama_stack/core/storage/datatypes.py
+++ b/src/llama_stack/core/storage/datatypes.py
@@ -255,6 +255,11 @@ class InferenceStoreReference(SqlStoreReference):
 class ResponsesStoreReference(InferenceStoreReference):
     """Responses store configuration with queue tuning."""
 
+    table_name: str = Field(
+        default="openai_responses",
+        description="Name of the table to use for storing OpenAI responses",
+    )
+
 
 class ServerStoresConfig(BaseModel):
     metadata: KVStoreReference | None = Field(

--- a/src/llama_stack/providers/utils/responses/responses_store.py
+++ b/src/llama_stack/providers/utils/responses/responses_store.py
@@ -57,7 +57,7 @@ class ResponsesStore:
         self.sql_store = AuthorizedSqlStore(base_store, self.policy)
 
         await self.sql_store.create_table(
-            "openai_responses",
+            self.reference.table_name,
             {
                 "id": ColumnDefinition(type=ColumnType.STRING, primary_key=True),
                 "created_at": ColumnType.INTEGER,
@@ -112,7 +112,7 @@ class ResponsesStore:
         data["messages"] = [msg.model_dump() for msg in messages]
 
         await self.sql_store.upsert(
-            table="openai_responses",
+            table=self.reference.table_name,
             data={
                 "id": data["id"],
                 "created_at": data["created_at"],
@@ -137,7 +137,7 @@ class ResponsesStore:
         data["messages"] = [msg.model_dump() for msg in messages]
 
         await self.sql_store.insert(
-            "openai_responses",
+            self.reference.table_name,
             {
                 "id": data["id"],
                 "created_at": data["created_at"],
@@ -172,7 +172,7 @@ class ResponsesStore:
             where_conditions["model"] = model
 
         paginated_result = await self.sql_store.fetch_all(
-            table="openai_responses",
+            table=self.reference.table_name,
             where=where_conditions if where_conditions else None,
             order_by=[("created_at", order.value)],
             cursor=("id", after) if after else None,
@@ -195,7 +195,7 @@ class ResponsesStore:
             raise ValueError("Responses store is not initialized")
 
         row = await self.sql_store.fetch_one(
-            "openai_responses",
+            self.reference.table_name,
             where={"id": response_id},
         )
 
@@ -210,10 +210,10 @@ class ResponsesStore:
         if not self.sql_store:
             raise ValueError("Responses store is not initialized")
 
-        row = await self.sql_store.fetch_one("openai_responses", where={"id": response_id})
+        row = await self.sql_store.fetch_one(self.reference.table_name, where={"id": response_id})
         if not row:
             raise ValueError(f"Response with id {response_id} not found")
-        await self.sql_store.delete("openai_responses", where={"id": response_id})
+        await self.sql_store.delete(self.reference.table_name, where={"id": response_id})
         return OpenAIDeleteResponseObject(id=response_id)
 
     async def list_response_input_items(

--- a/tests/unit/utils/responses/test_responses_store.py
+++ b/tests/unit/utils/responses/test_responses_store.py
@@ -193,7 +193,8 @@ async def test_responses_store_pagination_invalid_after():
         await store.initialize()
 
         # Try to paginate with non-existent ID
-        with pytest.raises(ValueError, match="Record with id.*'non-existent' not found in table 'openai_responses'"):
+        # Note: build_store uses table_name="responses", so the error message reflects that
+        with pytest.raises(ValueError, match="Record with id.*'non-existent' not found in table 'responses'"):
             await store.list_responses(after="non-existent", limit=2)
 
 


### PR DESCRIPTION
## Summary
- Allow administrators to configure a custom database table name for storing OpenAI Responses
- Replace hardcoded `"openai_responses"` table name with configurable `table_name` field
- Maintain backward compatibility with default value `"openai_responses"`

## Changes
- Added `table_name` field with default `"openai_responses"` to `ResponsesStoreReference` in `datatypes.py`
- Replaced 7 hardcoded table name references in `responses_store.py` with `self.reference.table_name`
- Updated test assertion to match configured table name in error messages

## Test Plan
- [x] All 8 unit tests pass (`pytest tests/unit/utils/responses/`)
- [x] Pre-commit hooks pass (ruff, mypy, format)
- [x] Custom table name verified via unit tests using `table_name="responses"`
- [x] Default backward compatibility verified via default field value

## Usage

```yaml
storage:
  stores:
    responses:
      backend: sql_default
      table_name: my_custom_responses  # Optional, defaults to "openai_responses"
```

## Related Issues
- [RHAIENG-3025](https://issues.redhat.com/browse/RHAIENG-3025)